### PR TITLE
Fix icon import path

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { View, Image, Text } from "react-native";
 import React, { useState } from "react";
 import { Tabs, Stack } from "expo-router";
-import { icons } from "../../constants";
+import { icons } from "@/src/constants";
 
 interface TabIconProps {
   icon: any; // The source of the icon (e.g., from require() or a URI)

--- a/src/navigation/tabs/_layout.tsx
+++ b/src/navigation/tabs/_layout.tsx
@@ -1,7 +1,7 @@
 import { View, Image, Text } from "react-native";
 import React, { useState } from "react";
 import { Tabs } from "expo-router";
-import { icons } from "../../constants";
+import { icons } from "@/src/constants";
 
 interface TabIconProps {
   icon: any; // The source of the icon (e.g., from require() or a URI)


### PR DESCRIPTION
## Summary
- resolve missing `constants` module in tabs layout
- update navigation tabs layout to use path alias

## Testing
- `npx jest --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_b_6853b00eee44832bb8645cfcebad1189