### PR TITLE
Add Jest setup for backend with initial tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.js'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",
@@ -15,6 +16,8 @@
     "twilio": "^5.6.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -35,8 +35,13 @@ app.use('/auth', authRoutes);
 // مثال على استخدام حماية المسارات بواسطة ميدلوير المصادقة
 // app.use('/api/protected', checkAuth, protectedRoutes);
 
-// بدء الخادم
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`الخادم يعمل على المنفذ ${PORT}`);
-});
+// بدء الخادم فقط إذا تم تشغيل الملف مباشرةً
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`الخادم يعمل على المنفذ ${PORT}`);
+  });
+}
+
+// تصدير التطبيق لاستخدامه في الاختبارات
+module.exports = app;

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,0 +1,59 @@
+const app = require('../server');
+let server;
+let baseUrl;
+
+jest.mock('@supabase/supabase-js', () => {
+  const auth = {
+    signUp: jest.fn(() => Promise.resolve({ data: { user: { id: '1', email: 'test@example.com' } }, error: null })),
+    signInWithPassword: jest.fn(() => Promise.resolve({ data: { user: { id: '1', email: 'test@example.com' }, session: {} }, error: null }))
+  };
+  return { createClient: jest.fn(() => ({ auth })) };
+});
+
+jest.mock('../models/verificationCodes', () => ({
+  createOrUpdateVerificationCode: jest.fn(() => Promise.resolve({ code: '123456' })),
+  getVerificationStatus: jest.fn(() => Promise.resolve({ verified: true }))
+}));
+
+jest.mock('../utils/smsService', () => ({
+  validatePhoneNumber: jest.fn(() => true),
+  formatPhoneNumber: jest.fn((p) => p),
+  sendVerificationSMS: jest.fn(() => Promise.resolve())
+}));
+
+describe('Auth endpoints', () => {
+  beforeAll(done => {
+    server = app.listen(0, () => {
+      const { port } = server.address();
+      baseUrl = `http://localhost:${port}`;
+      done();
+    });
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('registers a user', async () => {
+    const res = await fetch(`${baseUrl}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com', password: 'secret', name: 'Test', phone: '0500000000' })
+    });
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.success).toBe(true);
+  });
+
+  it('logs in a user', async () => {
+    const res = await fetch(`${baseUrl}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com', password: 'secret' })
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.verification_required).toBe(false);
+  });
+});

--- a/backend/tests/recommendations.test.js
+++ b/backend/tests/recommendations.test.js
@@ -1,0 +1,49 @@
+const app = require('../server');
+let server;
+let baseUrl;
+
+const zones = [
+  { zone_id: 1, zone_name: 'Zone 1', total_popularity_score: 5, total_user_ratings: 5 },
+  { zone_id: 2, zone_name: 'Zone 2', total_popularity_score: 1, total_user_ratings: 1 }
+];
+const competitors = [
+  { zone_id: 1, business_type: 'barber', number_of_same_type_businesses: 1 },
+  { zone_id: 2, business_type: 'barber', number_of_same_type_businesses: 3 }
+];
+
+jest.mock('@supabase/supabase-js', () => {
+  const dataMap = {
+    Businesses: [],
+    Zones: zones,
+    Competitors: competitors
+  };
+  return {
+    createClient: jest.fn(() => ({
+      from: jest.fn((table) => ({
+        select: jest.fn(() => Promise.resolve({ data: dataMap[table], error: null }))
+      }))
+    }))
+  };
+});
+
+describe('GET /api/recommendations', () => {
+  beforeAll(done => {
+    server = app.listen(0, () => {
+      const { port } = server.address();
+      baseUrl = `http://localhost:${port}`;
+      done();
+    });
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('returns sorted recommendations', async () => {
+    const res = await fetch(`${baseUrl}/api/recommendations/barber?count=2`);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.recommendations[0].zone_id).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- configure backend express app export
- add Jest config and dev dependencies
- create tests for auth and recommendation endpoints using fetch

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68544321b6d8832bb8dfedd582dfadda